### PR TITLE
Grab dependencies with a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ FruityMod.iml
 target/**
 dependency-reduced-pom.xml
 
+# Local dependency overrides
+dependency_overrides.properties
+
 # Downloaded dependencies
 ModTheSpire.jar
 desktop-1.0.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 FruityMod.iml
-bin/
 target/**
 dependency-reduced-pom.xml
 

--- a/bin/decrypt.sh
+++ b/bin/decrypt.sh
@@ -1,0 +1,6 @@
+source ./dependency_overrides.properties
+
+DESTINATION=`echo $1 | sed -E 's/(.*).gpg/\1/g'`
+
+echo "Decrypting $1, and saving as $DESTINATION"
+gpg --batch --passphrase $GPG_PASSPHRASE -d $1 > $DESTINATION

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -3,7 +3,7 @@ BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18
 
 getModTheSpireJar() {
   if [ -f ./ModTheSpire.jar ]; then
-    echo "ModTheSpire.jar found - skipping."
+    echo "ModTheSpire.jar already present - skipping."
   else
     echo "Downloading ModTheSpire.jar"
     curl -L $MOD_THE_SPIRE_ZIP_URL > ModTheSpire.zip
@@ -14,7 +14,7 @@ getModTheSpireJar() {
 
 getDesktopJar() {
   if [ -f ./desktop-1.0.jar ]; then
-    echo "desktop-1.0.jar found - skipping."
+    echo "desktop-1.0.jar already present - skipping."
   else
     echo "UNIMPLEMENTED!!!: Download desktop-1.0.jar"
   fi
@@ -26,7 +26,7 @@ makeModDirectory() {
 
 getBaseModJar() {
   if [ -f ./mods/BaseMod.jar ]; then
-    echo "./mods/BaseMod.jar found - skipping."
+    echo "./mods/BaseMod.jar already present - skipping."
   else
     echo "Downloading BaseMod.jar"
     curl -L $BASE_MOD_JAR_URL > ./mods/BaseMod.jar

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,12 +1,25 @@
 MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
 
 getModTheSpireJar() {
-  curl -L https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip > ModTheSpire.zip
-  unzip -d . ModTheSpire.zip ModTheSpire.jar
-  rm ModTheSpire.zip
+  if [ -f ./ModTheSpire.jar ]; then
+    echo "ModTheSpire.jar found - skipping."
+  else
+    echo "Downloading ModTheSpire.jar"
+    curl -L $MOD_THE_SPIRE_ZIP_URL > ModTheSpire.zip
+    unzip -d . ModTheSpire.zip ModTheSpire.jar
+    rm ModTheSpire.zip
+  fi
 }
 
-set -x
+getDesktopJar() {
+  if [ -f ./desktop-1.0.jar ]; then
+    echo "desktop-1.0.jar found - skipping."
+  else
+    echo "UNIMPLEMENTED!!!: Download desktop-1.0.jar"
+  fi
+}
+
 set -e
 
 getModTheSpireJar
+getDesktopJar

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,4 +1,5 @@
 MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
+BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
 
 getModTheSpireJar() {
   if [ -f ./ModTheSpire.jar ]; then
@@ -19,7 +20,22 @@ getDesktopJar() {
   fi
 }
 
+makeModDirectory() {
+  mkdir -p mods
+}
+
+getBaseModJar() {
+  if [ -f ./mods/BaseMod.jar ]; then
+    echo "./mods/BaseMod.jar found - skipping."
+  else
+    echo "Downloading BaseMod.jar"
+    curl -L $BASE_MOD_JAR_URL > ./mods/BaseMod.jar
+  fi
+}
+
 set -e
 
 getModTheSpireJar
 getDesktopJar
+makeModDirectory
+getBaseModJar

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,5 +1,6 @@
 MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
 BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
+DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/desktop-1.0.jar"
 
 getModTheSpireJar() {
   if [ -f ./ModTheSpire.jar ]; then
@@ -15,6 +16,9 @@ getModTheSpireJar() {
 getDesktopJar() {
   if [ -f ./desktop-1.0.jar ]; then
     echo "desktop-1.0.jar already present - skipping."
+  elif [ -f "$DESKTOP_JAR_LOCAL_PATH" ]; then
+    echo "Found desktop-1.0.jar in $DESKTOP_JAR_LOCAL_PATH - making a copy"
+    cp "$DESKTOP_JAR_LOCAL_PATH" ./
   else
     echo "UNIMPLEMENTED!!!: Download desktop-1.0.jar"
   fi

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -10,9 +10,9 @@ DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common
 # For a CI environment where desktop-1.0.jar is not installed
 #   Create a passphrase to encrypt your jar, and save as GPG_PASSPHRASE
 #   Use ./bin/encrypt.sh to encrypt your copy of the jar using your GPG_PASSPHRASE.
-#   Create an application in DropBox, and provided that application with a BearerToken - save that token in DROPBOX_BEARER_TOKEN
+#   Create an Application in DropBox, and generate a Token for your Application - save that token in DROPBOX_BEARER_TOKEN
 #   Upload your encrypted jar in your DropBox Application's folder.  Save the path in DROPBOX_ENCRYPTED_DESKTOP_JAR_PATH
-#   Test this on your local machine by clearning out DESKTOP_JAR_LOCAL_PATH (ie: DESKTOP_JAR_LOCAL_PATH='')
+#   Test this on your local machine by clearing out DESKTOP_JAR_LOCAL_PATH (ie: DESKTOP_JAR_LOCAL_PATH='')
 if [ -f dependency_overrides.properties ]; then
   source dependency_overrides.properties
 fi

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -2,6 +2,10 @@ MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v
 BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
 DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/desktop-1.0.jar"
 
+if [ -f dependency_overrides.properties ]; then
+  source dependency_overrides.properties
+fi
+
 getModTheSpireJar() {
   if [ -f ./ModTheSpire.jar ]; then
     echo "ModTheSpire.jar already present - skipping."

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,0 +1,12 @@
+MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
+
+getModTheSpireJar() {
+  curl -L https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip > ModTheSpire.zip
+  unzip -d . ModTheSpire.zip ModTheSpire.jar
+  rm ModTheSpire.zip
+}
+
+set -x
+set -e
+
+getModTheSpireJar

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -41,9 +41,19 @@ getBaseModJar() {
   fi
 }
 
+getFruityModJar() {
+  if [ -f ./mods/FruityMod.jar ]; then
+    echo "./mods/FruityMod.jar already present - skipping."
+  else
+    echo "Building FruityMod.jar"
+    mvn package
+  fi
+}
+
 set -e
 
 getModTheSpireJar
 getDesktopJar
 makeModDirectory
 getBaseModJar
+getFruityModJar

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -90,8 +90,6 @@ getFruityModJar() {
   fi
 }
 
-set -e
-
 getModTheSpireJar
 getDesktopJar
 makeModDirectory

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,9 +1,11 @@
 MOD_THE_SPIRE_LATEST_RELEASE_URL=https://github.com/kiooeht/ModTheSpire/releases/latest
-#MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
 BASE_MOD_LATEST_RELEASE_URL=https://github.com/daviscook477/BaseMod/releases/latest
-#BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
 DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/desktop-1.0.jar"
 
+# Add the lines below to dependency_overrides.properties, to override any of the dependency locations above
+#   MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/<SOME VERSION>/ModTheSpire.zip
+#   BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/<SOME VERSION>/BaseMod.jar
+#   DESKTOP_JAR_LOCAL_PATH=<SOME DIFFERENT LOCAL PATH>
 if [ -f dependency_overrides.properties ]; then
   source dependency_overrides.properties
 fi

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,4 +1,5 @@
-MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
+MOD_THE_SPIRE_LATEST_RELEASE_URL=https://github.com/kiooeht/ModTheSpire/releases/latest
+#MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
 BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
 DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/desktop-1.0.jar"
 
@@ -9,11 +10,20 @@ fi
 getModTheSpireJar() {
   if [ -f ./ModTheSpire.jar ]; then
     echo "ModTheSpire.jar already present - skipping."
-  else
-    echo "Downloading ModTheSpire.jar"
+    return
+  fi
+
+  if [ -z $MOD_THE_SPIRE_ZIP_URL ]; then
+    MOD_THE_SPIRE_ZIP_URL=`curl $MOD_THE_SPIRE_LATEST_RELEASE_URL 2> /dev/null | sed -E "s/.*href=\"([^\"]*)\".*/\1\/ModTheSpire.zip/g; s/tag/download/g"`
+  fi
+
+  if [ ! -z $MOD_THE_SPIRE_ZIP_URL ]; then
+    echo "Downloading ModTheSpire.jar from $MOD_THE_SPIRE_ZIP_URL"
     curl -L $MOD_THE_SPIRE_ZIP_URL > ModTheSpire.zip
     unzip -d . ModTheSpire.zip ModTheSpire.jar
     rm ModTheSpire.zip
+  else
+    echo "Could not download ModTheSpire.jar - try downloading it manually from $MOD_THE_SPIRE_LATEST_RELEASE_URL"
   fi
 }
 

--- a/bin/download_dependencies.sh
+++ b/bin/download_dependencies.sh
@@ -1,6 +1,7 @@
 MOD_THE_SPIRE_LATEST_RELEASE_URL=https://github.com/kiooeht/ModTheSpire/releases/latest
 #MOD_THE_SPIRE_ZIP_URL=https://github.com/kiooeht/ModTheSpire/releases/download/v2.9.1/ModTheSpire.zip
-BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
+BASE_MOD_LATEST_RELEASE_URL=https://github.com/daviscook477/BaseMod/releases/latest
+#BASE_MOD_JAR_URL=https://github.com/daviscook477/BaseMod/releases/download/v2.18.0/BaseMod.jar
 DESKTOP_JAR_LOCAL_PATH="$HOME/Library/Application Support/Steam/steamapps/common/SlayTheSpire/SlayTheSpire.app/Contents/Resources/desktop-1.0.jar"
 
 if [ -f dependency_overrides.properties ]; then
@@ -45,9 +46,18 @@ makeModDirectory() {
 getBaseModJar() {
   if [ -f ./mods/BaseMod.jar ]; then
     echo "./mods/BaseMod.jar already present - skipping."
-  else
-    echo "Downloading BaseMod.jar"
+    return
+  fi
+
+  if [ -z $BASE_MOD_JAR_URL ]; then
+    BASE_MOD_JAR_URL=`curl $BASE_MOD_LATEST_RELEASE_URL 2> /dev/null | sed -E "s/.*href=\"([^\"]*)\".*/\1\/BaseMod.jar/g; s/tag/download/g"`
+  fi
+
+  if [ ! -z $BASE_MOD_JAR_URL ]; then
+    echo "Downloading BaseMod.jar from $BASE_MOD_JAR_URL"
     curl -L $BASE_MOD_JAR_URL > ./mods/BaseMod.jar
+  else
+    echo "Could not download BaseMod.jar - try downloading it manually from $BASE_MOD_LATEST_RELEASE_URL"
   fi
 }
 

--- a/bin/encrypt.sh
+++ b/bin/encrypt.sh
@@ -1,0 +1,4 @@
+source ./dependency_overrides.properties
+
+echo "Encrypting $1 and saving as $1.gpg"
+gpg --symmetric --batch --no-symkey-cache -c --cipher-algo AES256 --passphrase $GPG_PASSPHRASE $1


### PR DESCRIPTION
- New ./bin/download_dependencies.sh script, to automatically find/grab all dependencies
  - For ModTheSpire.jar, and BaseMod.jar, always grab the latest by default
  - For desktop-1.0.jar, look locally, or optionally pull an encrypted copy out of DropBox
  - For FruityMod.jar, build the jar once all dependencies are available.
- Use dependency_overrides.properties to override any of the defaults