### PR TITLE
Fix the travisCI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/boommies/FruityMod-StS.svg?branch=master)](https://travis-ci.com/boommies/FruityMod-StS)
+[![Build Status](https://travis-ci.com/gskleres/FruityMod-StS.svg?branch=master)](https://travis-ci.com/gskleres/FruityMod-StS)
 
 # FruityMod-StS
 **Fruity Mod** for **Slay The Spire**


### PR DESCRIPTION
- The badge is pointing to the wrong repo.  Point it to the gskleres repo.