### PR TITLE
Issue #229 - always load Tranquil color and cards

### DIFF
--- a/src/main/java/fruitymod/FruityMod.java
+++ b/src/main/java/fruitymod/FruityMod.java
@@ -60,9 +60,7 @@ public class FruityMod implements PostInitializeSubscriber,
         BaseMod.subscribe(this);
         mods = new ArrayList<>();
         mods.add(new SeekerMod());
-        if (TranquilMod.isEnabled()) {
-			mods.add(new TranquilMod());
-		}
+        mods.add(new TranquilMod());
     }
 
     public static void initialize() {

--- a/src/main/java/fruitymod/TranquilMod.java
+++ b/src/main/java/fruitymod/TranquilMod.java
@@ -59,12 +59,18 @@ public class TranquilMod implements CharacterMod {
 
 		for(CustomCard card : cards) {
 			BaseMod.addCard(card);
-			UnlockTracker.unlockCard(card.cardID);
+			if (isEnabled()) {
+				UnlockTracker.unlockCard(card.cardID);
+			}
 		}
 	}
 
 	@Override
 	public void receiveEditCharacters() {
+		if (!isEnabled()) {
+			return;
+		}
+
 		logger.info("add " + TheTranquilEnum.THE_TRANQUIL.toString());
 		BaseMod.addCharacter(TheTranquil.class, "The Tranquil", "Tranquil class string",
 				AbstractCardEnum.TRANQUIL_TAN, "The Tranquil",
@@ -79,6 +85,10 @@ public class TranquilMod implements CharacterMod {
 
 	@Override
 	public void receiveEditRelics() {
+		if (!isEnabled()) {
+			return;
+		}
+
 		// Add relics
 		BaseMod.addRelicToCustomPool(new FangedNecklace(), AbstractCardEnum.TRANQUIL_TAN);
 	}


### PR DESCRIPTION
- Colors are loaded by Enum, which cannot be avoided.  Java doesn't really support dynamically adding/removing Enums.
- Therefore, change the behavior of the tranquil_enabled flag
    - Always load tranquil color
    - Always load tranquil cards, but leave them locked if tranquil is not enabled
    - Only load relics if tranquil is enabled
    - Only make Tranquil selectable if tranquil is enabled
- We should put in a PR to BaseMod's compendium code.  Rather than loading Compendium colors by Enum, track colors that were added through BaseMod.addColor, and only render cards for colors added that way.
  - See: https://github.com/daviscook477/BaseMod/blob/1336c7c4a085ba9e4f1a7526c44d28f2263c225a/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/mainMenu/ColorTabBar/ColorTabBarFix.java#L105