### PR TITLE
Create a new 1.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>fruitymod</groupId>
 	<artifactId>FruityMod</artifactId>
-	<version>0.1.0</version>
+	<version>1.0.0</version>
 
 	<name>Fruity Mod</name>
 	<description>Currently, adds a few new relics.</description>

--- a/src/main/java/fruitymod/FruityMod.java
+++ b/src/main/java/fruitymod/FruityMod.java
@@ -41,7 +41,7 @@ public class FruityMod implements PostInitializeSubscriber,
 	
     private static final String MODNAME = "FruityMod";
     private static final String AUTHOR = "Fruitstrike, ColdRain451, test447, fiiiiilth, Blank The Evil & Pal";
-    private static final String DESCRIPTION = "v0.7.1\n Adds The Seeker as a playable third character";
+    private static final String DESCRIPTION = "v1.0.0\n Adds The Seeker as a playable third character";
     private static final String FRUITY_MOD_ASSETS_FOLDER = "img";
 
 	// badge

--- a/src/main/resources/ModTheSpire.json
+++ b/src/main/resources/ModTheSpire.json
@@ -4,7 +4,7 @@
 	"author_list": ["Fruitstrike", "ColdRain451", "test447", "fiiiiilth", "Blank The Evil", "Pal", "Grumpai", "Jrawly", "Butcherberries"],
 	"description": "Adds The Seeker as a new playable character.",
 	"dependencies": ["basemod"],
-	"version": "0.7.1",
+	"version": "1.0.0",
 	"mts_version": "3.1.0",
 	"sts_version": "08-30-2018",
 	"update_json": "https://api.github.com/repos/gskleres/FruityMod-StS/releases/latest"


### PR DESCRIPTION
- Fix for Issue #229, show Tranquil cards, but Locked, unless tranquil is enabled.
- Add new FangedNecklace Relic, if tranquil is enabled.