### PR TITLE
Updating MeteorShower and VoidRay to use new MindBlastEffect with 3rd parameter

### DIFF
--- a/src/main/java/fruitymod/seeker/cards/MeteorShower.java
+++ b/src/main/java/fruitymod/seeker/cards/MeteorShower.java
@@ -34,7 +34,7 @@ public class MeteorShower extends CustomCard {
 
 	@Override
 	public void use(AbstractPlayer p, AbstractMonster m) {
-		AbstractDungeon.actionManager.addToBottom(new VFXAction(new MindblastEffect(p.dialogX, p.dialogY)));
+		AbstractDungeon.actionManager.addToBottom(new VFXAction(new MindblastEffect(p.dialogX, p.dialogY, false)));
 		AbstractDungeon.actionManager.addToBottom(new DamageAllEnemiesAction(p, this.multiDamage, this.damageTypeForTurn, AbstractGameAction.AttackEffect.NONE));
 		this.setDescription(false);
 	}

--- a/src/main/java/fruitymod/seeker/cards/VoidRay.java
+++ b/src/main/java/fruitymod/seeker/cards/VoidRay.java
@@ -38,7 +38,7 @@ extends CustomCard {
 
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
-        AbstractDungeon.actionManager.addToBottom(new VFXAction(new MindblastEffect(p.dialogX, p.dialogY)));
+        AbstractDungeon.actionManager.addToBottom(new VFXAction(new MindblastEffect(p.dialogX, p.dialogY, false)));
         AbstractDungeon.actionManager.addToBottom(new DamageAction((AbstractCreature)m, new DamageInfo(p, this.damage, DamageInfo.DamageType.NORMAL), AbstractGameAction.AttackEffect.NONE));
         AbstractDungeon.actionManager.addToBottom(new MakeTempCardInDrawPileAction(new Dazed(), 1, true, true));
     }

--- a/src/main/java/fruitymod/seeker/characters/TheSeeker.java
+++ b/src/main/java/fruitymod/seeker/characters/TheSeeker.java
@@ -6,7 +6,6 @@ import basemod.animations.SpriterAnimation;
 import com.megacrit.cardcrawl.actions.utility.ExhaustAllEtherealAction;
 import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.core.Settings;
-import com.megacrit.cardcrawl.daily.DailyMods;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.screens.CharSelectInfo;
@@ -41,10 +40,6 @@ public class TheSeeker extends CustomPlayer {
 				SeekerMod.makePath(SeekerMod.SEEKER_SHOULDER_1),
 				SeekerMod.makePath(SeekerMod.SEEKER_CORPSE),
 				getLoadout(), 20.0F, -10.0F, 220.0F, 290.0F, new EnergyManager(ENERGY_PER_TURN));
-
-		if (Settings.dailyModsEnabled() && DailyMods.cardMods.get("Diverse")) {
-			this.masterMaxOrbs = 1;
-		}
 	}
 	
 	@Override

--- a/src/main/java/fruitymod/tranquil/characters/TheTranquil.java
+++ b/src/main/java/fruitymod/tranquil/characters/TheTranquil.java
@@ -5,7 +5,6 @@ import basemod.animations.SpriterAnimation;
 import com.megacrit.cardcrawl.actions.utility.ExhaustAllEtherealAction;
 import com.megacrit.cardcrawl.core.EnergyManager;
 import com.megacrit.cardcrawl.core.Settings;
-import com.megacrit.cardcrawl.daily.DailyMods;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.powers.AbstractPower;
 import com.megacrit.cardcrawl.screens.CharSelectInfo;
@@ -40,10 +39,6 @@ public class TheTranquil extends CustomPlayer {
 				TranquilMod.makeCharacterImagePath("shoulder"),
 				TranquilMod.makeCharacterImagePath("corpse"),
 				getLoadout(), 20.0F, -10.0F, 220.0F, 290.0F, new EnergyManager(ENERGY_PER_TURN));
-
-		if (Settings.dailyModsEnabled() && DailyMods.cardMods.get("Diverse")) {
-			this.masterMaxOrbs = 1;
-		}
 	}
 	
 	@Override


### PR DESCRIPTION
MindBlastEffect has an additional boolean flipHorizontal parameter.
MeteorShower and VoidRay currently hit an exception when the cards are attempted to be played because of this discrepancy with the base game

Removed dependencies on deprecated DailyMod that prevented class from initializing with latest patch.